### PR TITLE
fix a uart lite implementation bug

### DIFF
--- a/src/main/scala/sifive-blocks/devices/uart/UART.scala
+++ b/src/main/scala/sifive-blocks/devices/uart/UART.scala
@@ -248,7 +248,7 @@ trait HasUARTTopModuleContents extends HasUARTParameters with HasRegMap {
     UARTCtrlRegs.stat -> Seq(
       RegField.r(1, rxq.io.count =/= UInt(0)),
       RegField.r(1, rxq.io.count === UInt(uartNRxEntries)),
-      RegField.r(1, txq.io.count =/= UInt(0)),
+      RegField.r(1, txq.io.count === UInt(0)),
       RegField.r(1, txq.io.count === UInt(uartNTxEntries)),
       RegField.r(1, UInt(0)),
       RegField.r(1, UInt(0)),


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
According to [AXI UART Lite v2.0 LogiCORE IP Product Guide p12](https://www.xilinx.com/support/documentation/ip_documentation/axi_uartlite/v2_0/pg142-axi-uartlite.pdf), Bit 2 of status register should be 1 when Transmit FIFO is empty.